### PR TITLE
Hash table Resize

### DIFF
--- a/data-structures/hash-tables/ht.go
+++ b/data-structures/hash-tables/ht.go
@@ -4,9 +4,8 @@
 package ht
 
 import (
-	list "algorithms-3/data-structures/linked-list"
+	list "algorithms2/data-structures/linked-list"
 	"errors"
-	"github.com/arnauddri/algorithms/data-structures/linked-list"
 	"math"
 )
 

--- a/data-structures/hash-tables/ht.go
+++ b/data-structures/hash-tables/ht.go
@@ -4,6 +4,7 @@
 package ht
 
 import (
+	list "algorithms-3/data-structures/linked-list"
 	"errors"
 	"github.com/arnauddri/algorithms/data-structures/linked-list"
 	"math"
@@ -114,4 +115,18 @@ func hashCode(s string) int {
 		hash &= hash
 	}
 	return int(math.Abs(float64(hash)))
+}
+
+// Resizes table to desired capacity. ( if Possible )
+func (ht *HashTable) Resize(newCap int) error {
+	size := ht.Size
+	if ht.Capacity == newCap {
+		return errors.New("current capacity is as same the input number")
+	}
+	if newCap >= size {
+		ht.Capacity = newCap
+	} else {
+		return errors.New("there is not enough capacity to hold items. please enter a larger number")
+	}
+	return nil
 }

--- a/data-structures/hash-tables/ht.go
+++ b/data-structures/hash-tables/ht.go
@@ -4,8 +4,8 @@
 package ht
 
 import (
-	list "../linked-list"
 	"errors"
+	list "github.com/arnauddri/algorithms/data-structures/linked-list"
 	"math"
 )
 

--- a/data-structures/hash-tables/ht.go
+++ b/data-structures/hash-tables/ht.go
@@ -4,7 +4,7 @@
 package ht
 
 import (
-	list "algorithms2/data-structures/linked-list"
+	list "../linked-list"
 	"errors"
 	"math"
 )

--- a/data-structures/hash-tables/ht_test.go
+++ b/data-structures/hash-tables/ht_test.go
@@ -55,3 +55,32 @@ func TestHash(t *testing.T) {
 		t.Error()
 	}
 }
+
+func TestHashTable_Resize(t *testing.T) {
+	ht := New(1000)
+	ht.Put("foo", "bar")
+	ht.Put("fiz", "buzz")
+	ht.Put("bruce", "wayne")
+	ht.Put("peter", "parker")
+	ht.Put("clark", "kent")
+
+	actual := ht.Resize(10)
+
+	if actual != nil {
+		t.Errorf("resul = %v, want nil", actual)
+	}
+
+	actual = ht.Resize(10)
+	expected := "current capacity is as same the input number"
+
+	if actual.Error() != expected {
+		t.Errorf("resul = %v, want %v", actual, expected)
+	}
+
+	actual = ht.Resize(4)
+	expected = "there is not enough capacity to hold items. please enter a larger number"
+
+	if actual.Error() != expected {
+		t.Errorf("resul = %v, want %v", actual, expected)
+	}
+}


### PR DESCRIPTION
We implemented an API for resizing the hashtable in case of need. Clearly, the new capacity being greater than the current size of the hashtable is necessary to hold. There are also tests for different cases that prove the functionality of the new Resize method. 