### PR TITLE
fix condition of Add in Linked List

### DIFF
--- a/data-structures/linked-list/linked_list.go
+++ b/data-structures/linked-list/linked_list.go
@@ -79,7 +79,7 @@ func (l *List) Add(value interface{}, index int) error {
 		return nil
 	}
 
-	if l.Len()-1 == index {
+	if l.Len() == index {
 		l.Append(value)
 		return nil
 	}


### PR DESCRIPTION
There was a tiny problem with the condition. when the index is equal to the length of the list we must append it to the tail not when it's equal to length - 1. The reason is that we start counting from zero therefore we should have at least length + 1 spot for inserting a node( counting length from zero). I guess you didn't notice because the tests actually didn't cover it.

